### PR TITLE
MutableMapping moved to collections.abc

### DIFF
--- a/unittest2/compatibility.py
+++ b/unittest2/compatibility.py
@@ -140,7 +140,7 @@ except ImportError:
 ###  ChainMap (helper for configparser and string.Template)
 ########################################################################
 
-class ChainMap(collections.MutableMapping):
+class ChainMap(collections.abc.MutableMapping):
     ''' A ChainMap groups multiple dicts (or other mappings) together
     to create a single, updateable view.
 


### PR DESCRIPTION
This seems to be the case since python 3.3